### PR TITLE
Bump Wordpress image version to PHP 7.4

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM wordpress:php7.2
+FROM wordpress:php7.4
 
 ARG VOLUME
 ARG HOST_GUID


### PR DESCRIPTION
This PR bumps Wordpress image version to PHP 7.4.