### PR TITLE
Improve Wordmove features

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,9 @@ services:
     depends_on:
       - kwp
     restart: on-failure:5
-    image: welaika/wordmove
+    build:
+      context: ./docker
+      dockerfile: Wordmove.dockerfile
     volumes:
       - ./wp_html:/var/www/html
       - ./themes:/var/www/html/wp-content/themes

--- a/docker/Wordmove.dockerfile
+++ b/docker/Wordmove.dockerfile
@@ -1,0 +1,3 @@
+FROM welaika/wordmove:latest
+
+RUN apt-get update && apt-get install -y php-xml

--- a/movefile.yml
+++ b/movefile.yml
@@ -1,5 +1,5 @@
 global:
-  sql_adapter: default
+  sql_adapter: wpcli
 
 local:
   vhost: "<%= ENV['SITE_URL'] %>"


### PR DESCRIPTION
The purpose of this PR is to improve some Wordmove features in Kayak in order two work better with our internal workflow.

Specifically, this PR:

- Modifies the `sql_adapter` specified in the `movefile.yml` example file to be `wpcli` instead of `default`. The original adapter in some cases would make Wordmove fail because of some DB encoding errors
- Builds the Wordmove container from a custom file instead of just using the `welaika/wordmove` image. This is necessary in order to add `php-xml` to the container, which is a requirement if you are using `wpcli` as the `sql_adapter` and if the Wordpress site requires xml functions; for example, if WPML is present then Wordmove will fail with this error:
  ```
  PHP Fatal error:  Uncaught Error: Call to undefined function simplexml_load_file() in /var/www/html/wp-content/plugins/sitepress-multilingual-cms/vendor/otgs/installer/includes/class-wp-installer.php:880
  ```